### PR TITLE
Two new features and a small fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,31 @@ in the appropriate location.
         Copied images/awesome-sauce.jpg to /tmp/django_media/images/awesome-sauce.jpg
 
 
+CONFIGURATION
+-------------
+
+* `FIXTURE_MEDIA_REQUIRE_PREFIX` (default: `False`)
+
+  By default, the management command will try to copy everything that resembles
+  a file path; if you have a lot of entries in your fixtures that looks like
+  file paths but is not actually one, you can specify
+  `FIXTURE_MEDIA_REQUIRE_PREFIX = True` in settings.py to make 
+  `./manage.py collectmedia` copy only files that are prefixed with `media://`.
+
+  Example:
+
+        [
+            {
+                "pk": 1,
+                "model": "myapp.mymodel",
+                "fields": {
+                    "name": "Awesome Sauce",
+                    "image": "media://images/awesome-sauce.jpg"
+                    "path": "this/is/ignored/awesome-sauce.jpg"
+                }
+            }
+        ]
+
 Thanks
 ------
 lieryan

--- a/fixture_media/management/commands/_utils.py
+++ b/fixture_media/management/commands/_utils.py
@@ -1,2 +1,3 @@
 import re
-file_patt = re.compile(r'"([^"]+?[\/\\]+[^"]+?\.[^."]+?)"')
+file_patt = re.compile(r'"(?:media://)?([^"]+?[\/\\]+[^"]+?\.[^."]+?)"')
+file_patt_prefixed = re.compile(r'"media://([^"]+?[\/\\]+[^"]+?\.[^."]+?)"')

--- a/fixture_media/management/commands/collectmedia.py
+++ b/fixture_media/management/commands/collectmedia.py
@@ -3,9 +3,10 @@ from shutil import copy
 
 from django.core.management.base import CommandError, NoArgsCommand
 from django.db.models import get_apps
+from django.conf import settings
 from optparse import make_option
 
-from ._utils import file_patt
+from ._utils import file_patt, file_patt_prefixed
 
 
 class Command(NoArgsCommand):
@@ -46,8 +47,13 @@ class Command(NoArgsCommand):
             if not confirm.startswith('y'):
                 raise CommandError("Media syncing aborted")
 
+        if getattr(settings, 'FIXTURE_MEDIA_REQUIRE_PREFIX', False):
+            pattern = file_patt_prefixed
+        else:
+            pattern = file_patt
+
         for root, fixture in json_fixtures:
-            file_paths = file_patt.findall(open(fixture).read())
+            file_paths = pattern.findall(open(fixture).read())
             if file_paths:
                 for fp in file_paths:
                     fixture_media = os.path.join(root, 'media')

--- a/test.py
+++ b/test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from fixture_media.management.commands._utils import file_patt
+from fixture_media.management.commands._utils import file_patt, file_patt_prefixed
 
 JSON = """
 {
@@ -7,8 +7,13 @@ JSON = """
         "foo1": "bar/baz/bing/bang.foo"
         "foo2": "bar//baz//bing//bang.foo"
         "foo3": "bar\\baz\\bing\\bang.foo"
+        "foo1": "media://pbar/baz/bing/bang.foo"
+        "foo2": "media://pbar//baz//bing//bang.foo"
+        "foo3": "media://pbar\\baz\\bing\\bang.foo"
     }
 }
 """
 
-assert len(file_patt.findall(JSON)) == 3
+assert file_patt.findall(JSON) == ['bar/baz/bing/bang.foo', 'bar//baz//bing//bang.foo', 'bar\\baz\\bing\\bang.foo', 'pbar/baz/bing/bang.foo', 'pbar//baz//bing//bang.foo', 'pbar\\baz\\bing\\bang.foo']
+
+assert file_patt_prefixed.findall(JSON) == ['pbar/baz/bing/bang.foo', 'pbar//baz//bing//bang.foo', 'pbar\\baz\\bing\\bang.foo']


### PR DESCRIPTION
This pull request adds --no-input to the command to skip the prompt altogether (useful for scripts) and FIXTURE_MEDIA_REQUIRE_PREFIX option.

The latter feature is a more radical change, please advise if the option name and the default behaviour looks good.

PS: should I create two separate PRs?
