### PR TITLE
Edits for Python 3

### DIFF
--- a/fixture_media/management/commands/collectmedia.py
+++ b/fixture_media/management/commands/collectmedia.py
@@ -67,4 +67,3 @@ class Command(NoArgsCommand):
                         os.makedirs(dest_dir)
                     self.stdout.write('Copied %s to %s\n' % (fp, final_dest))
                     copy(fixture_path, final_dest)
-                    


### PR DESCRIPTION
These are the edits that allow django-fixturemedia to work with Python 3. 

Replaced .next() on line 38 in collectmedia.py to **next**(). Replaced raw_input on line 46 in the collectmedia.py to input("...")
