### PR TITLE
Fixture dirs from settings

### DIFF
--- a/fixture_media/management/commands/collectmedia.py
+++ b/fixture_media/management/commands/collectmedia.py
@@ -60,7 +60,8 @@ class Command(NoArgsCommand):
                     fixture_media = os.path.join(root, 'media')
                     fixture_path = os.path.join(fixture_media, fp)
                     if not os.path.exists(fixture_path):
-                        self.stderr.write("File path (%s) found in fixture but not on disk in (%s) \n" % (fp,fixture_path))
+                        if int(options['verbosity']) >= 1:
+                            self.stderr.write("File path (%s) found in fixture but not on disk in (%s) \n" % (fp,fixture_path))
                         continue
                     final_dest = os.path.join(settings.MEDIA_ROOT, fp)
                     dest_dir = os.path.dirname(final_dest)

--- a/fixture_media/management/commands/collectmedia.py
+++ b/fixture_media/management/commands/collectmedia.py
@@ -31,7 +31,8 @@ class Command(NoArgsCommand):
                 app_module_paths.append(app.__file__)
         
         app_fixtures = [os.path.join(os.path.dirname(path), 'fixtures') for path in app_module_paths]
-        
+        app_fixtures += list(settings.FIXTURE_DIRS) + ['']
+
         json_fixtures = []
         for fixture_path in app_fixtures:
             try:


### PR DESCRIPTION
Django's loaddata concerns not only app fixtures, but all fixtures, listed in "FIXTURE_DIRS" settings.
https://github.com/django/django/blob/d54022b6558e620563a2f09ed03f9676312710a9/django/core/management/commands/loaddata.py#L145

Also it'll be handy to mute errors output on "verbosity==0"
